### PR TITLE
Remove JS logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ DerivedData/
 .swiftpm/config/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
+logs


### PR DESCRIPTION
- This just hides the logs from uploading. There is nothing sensitive in the logs only dont want to overcrowd the codebase